### PR TITLE
We want to install oci-systemd-hook in /usr/libexec/docker/hooks.d

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-bin_PROGRAMS = oci_systemd_hook
+libexec_PROGRAMS = oci_systemd_hook
 oci_systemd_hook_SOURCES= systemdhook.c
 
 oci_systemd_hook_CFLAGS = $(YAJL_CFLAGS)


### PR DESCRIPTION
./configure --execdir=/usr/libexec/docker/hooks.d

Now will configure the tool to do this correctly.
