### PR TITLE
Don't set the tmpfs size

### DIFF
--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -156,9 +156,9 @@ int prestart(const char *rootfs,
 		}
 
 		if (!strcmp("", mount_label)) {
-			rc = asprintf(&options, "mode=1777,size=65536k");
+			rc = asprintf(&options, "mode=1777");
 		} else {
-			rc = asprintf(&options, "mode=1777,size=65536k,context=\"%s\"", mount_label);
+			rc = asprintf(&options, "mode=1777,context=\"%s\"", mount_label);
 		}
 		if (rc < 0) {
 			pr_perror("Failed to allocate memory for context");


### PR DESCRIPTION
If we do not set a size, it defaults to 1/2 of the system memory.
However cgroups still limit the usage of tmpfs.
We are allowed to roughly use 2 the cgroup memory limit in bytes.

Ideally, we should set it to half of that, which we can do in
a subsequent patch.

Signed-off-by: Mrunal Patel mrunalp@gmail.com
